### PR TITLE
Add MYSYS2 example to Windows compilation instructions, update MinGW instructions

### DIFF
--- a/COMPILING
+++ b/COMPILING
@@ -86,10 +86,12 @@ The install step can still be done:
 3. Compiling on Windows
 ========================
 
-To compile 1oom, you need a GNU build environment. This guide uses MinGW to
-compile the SDL2 version of 1oom. There are other options you may use, like
-Cygwin, MinGW-w64 or MSYS2, but in that case, you're on your own.
+To compile 1oom, you need a GNU build environment. This guide demonstrates
+using MinGW or MinGW-w64 to compile the SDL2 version of 1oom. There are other
+options you may use, like Cygwin or WSL, but in that case, you're on your own.
 
+Build with MinGW/MSYS
+---------------------
 Download and install mingw-get-setup.exe from: https://osdn.net/projects/mingw/releases/
 
 This will install a graphical package manager. Ensure that you install:
@@ -118,6 +120,39 @@ running configure, pass the following options:
 
 To run 1oom, place SDL2.dll and SDL2_mixer.dll from "C:\MinGW\bin" into the
 same directory as the binary.
+
+Build with MinGW-w64/MSYS2
+--------------------------
+Download and install MSYS2 from: https://www.msys2.org/
+
+Open the MSYS2 MINGW64 shell. You can use the MINGW32 shell to create a
+32-bit build if you want, but you'll need to replace any instances of "x86_64"
+with "i686" in the following section, and copy the DLLs shown later from the
+"mingw32/bin" folder instead.
+
+Install the following packages using 'pacman -S PACKAGE_NAME':
+   - mingw-w64-x86_64-toolchain
+   - mingw-w64-x86_64-autotools
+   - mingw-w64-x86_64-SDL2
+   - mingw-w64-x86_64-SDL2_mixer
+   - mingw-w64-x86_64-fluidsynth (optional)
+
+You are now ready to configure and build 1oom as described in Section 2. When
+running configure, pass the following options:
+    --disable-hwsdl1 --disable-hwalleg4 --disable-hwx11
+
+To run 1oom, you'll need to copy several DLLs from your MSYS2/mingw64 bin
+directory (usually C:\msys64\mingw64) to the same directory as the binary.
+The exact ones needed vary depending on which features you intend to use, but
+the bare minimum to run this build of 1oom are:
+    - libmpg123-0.dll
+    - libogg-0.dll
+    - libopus-0.dll
+    - libopusfile-0.dll
+    - SDL2.dll
+    - SDL2_mixer.dll
+
+and finally libfluidsynth-3.dll if you opted into install fluidsynth above.
 
 
 4. Cross-compiling

--- a/COMPILING
+++ b/COMPILING
@@ -92,34 +92,31 @@ Cygwin, MinGW-w64 or MSYS2, but in that case, you're on your own.
 
 Download and install mingw-get-setup.exe from: https://osdn.net/projects/mingw/releases/
 
-This will install a graphical package manager. Ensure that you have the latest autoconf,
-automake and make versions available and also MSYS.
+This will install a graphical package manager. Ensure that you install:
+    - mingw32-autotools-bin
+    - mingw32-base-bin
+    - msys-base-bin
 
 Download the SDL2 development libarary for MinGW from:
-    https://www.libsdl.org/download-2.0.php
+    https://github.com/libsdl-org/SDL/releases
 
 Download the SDL2 mixer development library for MinGW from:
-    https://www.libsdl.org/projects/SDL_mixer/
+    https://github.com/libsdl-org/SDL_mixer/releases
 
-Then unzip the two archives you downloaded.
+Both archives contain a "i686-w64-mingw32" folder. Extract the the 'bin', 'include',
+and 'lib' folders within each to your MinGW directory (usually "C:\MinGW"),
+merging them with the existing folders there.
 
-Then, open a command prompt and run
-    C:\MinGW\msys\1.0\bin\sh
+Then, run:
+    C:\MinGW\msys\1.0\msys.bat
 
-which gives you a UNIX-style command prompt. First, add the MinGW binaries to
-your PATH:
-    PATH="/c/MinGW/bin:/c/MinGW/msys/1.0/bin:$PATH"
-
-Then, go to the directory where you extracted SDL2 and enter:
-    make native
-
-Do the same for SDL2 Mixer.
+which gives you a UNIX-style command prompt with the correct PATHs already configured.
 
 You are now ready to configure and build 1oom as described in Section 2. When
 running configure, pass the following options:
     --disable-hwsdl1 --disable-hwalleg4 --disable-hwx11
 
-To run 1oom, place the *32-bit* versions of SDL2.dll and SDL2_mixer.dll in the
+To run 1oom, place SDL2.dll and SDL2_mixer.dll from "C:\MinGW\bin" into the
 same directory as the binary.
 
 


### PR DESCRIPTION
This build procedure overall requires less work and avoids a bug with MinGW's SDL2_mixer package as detailed here:
https://gitlab.com/Tapani_/1oom/-/issues/68

Additionally, the build uses a package of SDL2_mixer that has fluidsynth support available, while the copy of SDL2_mixer acquired in the original instructions did not. This way, users can utilize their own soundfonts with the binaries that this procedure produces unlike before.

Not sure if fluidsynth support is enabled in artifacts added to the releases of this repository, though since the fluidsynth dll isn't included it won't work either way (unless you're linking it statically).

I didn't know if you would prefer this to be merged into a different branch, like core perhaps, but I assumed master was appropriate.

Not sure if/when I'll have the time, but eventually I'd like to follow this up with adding CMake build scripts (at least for Windows to start) to the repository.

