### PR TITLE
Change custom game 'Players' option text to 'Opponents'

### DIFF
--- a/src/ui/classic/uimainmenu.c
+++ b/src/ui/classic/uimainmenu.c
@@ -248,7 +248,7 @@ static struct main_menu_item_data_s mm_items[MAIN_MENU_ITEM_NUM] = {
     {
         MAIN_MENU_ITEM_TYPE_ENUM,
         NULL, NULL,
-        "Players", mm_get_custom_players_value, &game_opt_custom.players, 0,
+        "Opponents", mm_get_custom_players_value, &game_opt_custom.players, 0,
         2, PLAYER_NUM,
         MOO_KEY_p,
     },


### PR DESCRIPTION
The value this option sets is actually the number of opponents, as in the original game creation menu, and not the total number of players.

"Players" is misleading as it leads one to assume it includes themselves, and as such if they wanted to start a game with 3 opponents they'd likely set Players to 4; however, upon reaching the next screen they'd come to find that there were actually 4 opponents, with 5 players total.

Of course this also seems silly with just one opponent, as "Players 1" doesn't make any sense at first glance since you can't start a game with just one race.

The term "Player" could be kept and the logic behind the option shifted so that it instead is restricted between 2-6 in the UI, while actually passing it's value - 1 to the rest of the game setup, but this would obviously require more work.